### PR TITLE
Add proxy support and refactor MCP server functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: mypy
         args: []
-        additional_dependencies: ["mcp>=1.3.0", "pytest>=8.3.5", "youtube-transcript-api>=1.0.0"]
+        additional_dependencies: ["mcp>=1.3.0", "pytest>=8.3.5", "youtube-transcript-api>=1.0.1"]
   - repo: local
     hooks:
       - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: mypy
         args: []
-        additional_dependencies: ["mcp>=1.3.0", "pytest>=8.3.5", "youtube-transcript-api>=1.0.1"]
+        additional_dependencies: ["mcp>=1.3.0", "youtube-transcript-api>=1.0.1", "pytest>=8.3.5", "pytest-mock>=3.14"]
   - repo: local
     hooks:
       - id: pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Youtube Transcript MCP Server
+# YouTube Transcript MCP Server
 [![Python Application](https://github.com/jkawamoto/mcp-youtube-transcript/actions/workflows/python-app.yaml/badge.svg)](https://github.com/jkawamoto/mcp-youtube-transcript/actions/workflows/python-app.yaml)
 [![GitHub License](https://img.shields.io/github/license/jkawamoto/mcp-youtube-transcript)](https://github.com/jkawamoto/mcp-youtube-transcript/blob/main/LICENSE)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
@@ -8,6 +8,16 @@
 This MCP server retrieves transcripts for given YouTube video URLs.
 
 <a href="https://glama.ai/mcp/servers/of3kwtmlqp"><img width="380" height="200" src="https://glama.ai/mcp/servers/of3kwtmlqp/badge" alt="YouTube Transcript Server MCP server" /></a>
+
+## Tools
+This MCP server provides the following tools:
+
+### `get_transcript`
+Fetches the transcript of a specified YouTube video.
+
+#### Parameters
+- **url** *(string)*: The full URL of the YouTube video. This field is required.
+- **lang** *(string, optional)*: The desired language for the transcript. Defaults to `en` if not specified.
 
 ## Installation
 
@@ -60,22 +70,25 @@ After editing, restart the application.
 For more information,
 see: [For Claude Desktop Users - Model Context Protocol](https://modelcontextprotocol.io/quickstart/user).
 
-### Installing via Smithery
+#### Installing via Smithery
 To install Youtube Transcript for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jkawamoto/mcp-youtube-transcript):
 
 ```bash
 npx -y @smithery/cli install @jkawamoto/mcp-youtube-transcript --client claude
 ```
 
-## Tools
-This MCP server provides the following tools:
+## Using Proxy Servers
+In environments where access to YouTube is restricted, you can use proxy servers.
 
-### `get_transcript`
-Fetches the transcript of a specified YouTube video.
+When using [Webshare](https://www.webshare.io/), set the username and password for the Residential Proxy using either
+the environment variables `WEBSHARE_PROXY_USERNAME` and `WEBSHARE_PROXY_PASSWORD`,
+or the command line arguments `--webshare-proxy-username` and `--webshare-proxy-password`.
 
-#### Parameters
-- **url** *(string)*: The full URL of the YouTube video. This field is required.
-- **lang** *(string, optional)*: The desired language for the transcript. Defaults to `en` if not specified.
+When using other proxy servers, set the proxy server URL using either the environment variables `HTTP_PROXY` or
+`HTTPS_PROXY`, or the command line arguments `--http-proxy` or `--https-proxy`.
+
+For more details, please visit:
+[Working around IP bans - YouTube Transcript API](https://github.com/jdepoix/youtube-transcript-api?tab=readme-ov-file#working-around-ip-bans-requestblocked-or-ipblocked-exception).
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.3",
     "pydantic>=2.10.6",
-    "youtube-transcript-api>=1",
+    "youtube-transcript-api>=1.0.1",
 ]
 
 scripts.mcp-youtube-transcript = "mcp_youtube_transcript:main"
@@ -61,9 +61,3 @@ replace = 'version = "{new_version}"'
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
-
-[[tool.mypy.overrides]]
-module = [
-    "youtube_transcript_api",
-]
-ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "click>=8.1.8",
     "mcp>=1.3",
     "pydantic>=2.10.6",
     "youtube-transcript-api>=1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pre-commit>=4.1",
     "pre-commit-uv>=4.1.4",
     "pytest>=8.3.5",
+    "pytest-mock>=3.14",
 ]
 
 [tool.ruff]

--- a/src/mcp_youtube_transcript/__init__.py
+++ b/src/mcp_youtube_transcript/__init__.py
@@ -10,6 +10,7 @@ from logging import Logger
 from typing import Final
 from urllib.parse import urlparse, parse_qs
 
+import click
 from mcp.server import FastMCP
 from mcp.server.fastmcp.utilities import logging
 from pydantic import Field
@@ -43,7 +44,10 @@ def get_transcript(
     return "\n".join((item.text for item in transcripts))
 
 
+@click.command()
+@click.version_option()
 def main() -> None:
+    """YouTube Transcript MCP server."""
     logger.info("starting Youtube Transcript MCP server")
     mcp.run()
     logger.info("closed Youtube Transcript MCP server")

--- a/src/mcp_youtube_transcript/__init__.py
+++ b/src/mcp_youtube_transcript/__init__.py
@@ -8,56 +8,11 @@
 
 from logging import Logger
 from typing import Final
-from urllib.parse import urlparse, parse_qs
 
 import click
-from mcp.server import FastMCP
 from mcp.server.fastmcp.utilities import logging
-from pydantic import Field
-from youtube_transcript_api import YouTubeTranscriptApi
-from youtube_transcript_api.proxies import WebshareProxyConfig, GenericProxyConfig, ProxyConfig
 
-
-def server(
-    webshare_proxy_username: str | None,
-    webshare_proxy_password: str | None,
-    http_proxy: str | None,
-    https_proxy: str | None,
-) -> FastMCP:
-    """Initializes the MCP server."""
-
-    proxy_config: ProxyConfig | None = None
-    if webshare_proxy_username and webshare_proxy_password:
-        proxy_config = WebshareProxyConfig(webshare_proxy_username, webshare_proxy_password)
-    elif http_proxy or https_proxy:
-        proxy_config = GenericProxyConfig(http_proxy, https_proxy)
-
-    ytt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
-
-    mcp = FastMCP("Youtube Transcript")
-
-    @mcp.tool()
-    def get_transcript(
-        url: str = Field(description="The URL of the YouTube video"),
-        lang: str = Field(description="The preferred language for the transcript", default="en"),
-    ) -> str:
-        """Retrieves the transcript of a YouTube video."""
-        parsed_url = urlparse(url)
-        query_params = parse_qs(parsed_url.query)
-
-        video_id = query_params.get("v", [None])[0]
-        if video_id is None:
-            raise ValueError(f"couldn't find a video ID from the provided URL: {url}.")
-
-        if lang == "en":
-            languages = ["en"]
-        else:
-            languages = [lang, "en"]
-        transcripts = ytt_api.fetch(video_id, languages=languages)
-
-        return "\n".join((item.text for item in transcripts))
-
-    return mcp
+from mcp_youtube_transcript.server import new_server
 
 
 @click.command()
@@ -87,7 +42,7 @@ def main(
     logger: Final[Logger] = logging.get_logger(__name__)
 
     logger.info("starting Youtube Transcript MCP server")
-    mcp = server(webshare_proxy_username, webshare_proxy_password, http_proxy, https_proxy)
+    mcp = new_server(webshare_proxy_username, webshare_proxy_password, http_proxy, https_proxy)
     mcp.run()
     logger.info("closed Youtube Transcript MCP server")
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,103 @@
+#  test_mcp.py
+#
+#  Copyright (c) 2025 Junpei Kawamoto
+#
+#  This software is released under the MIT License.
+#
+#  http://opensource.org/licenses/mit-license.php
+import os
+from typing import AsyncGenerator
+
+import pytest
+from mcp import StdioServerParameters, stdio_client, ClientSession
+from mcp.types import TextContent
+from youtube_transcript_api import YouTubeTranscriptApi
+
+params = StdioServerParameters(command="uv", args=["run", "mcp-youtube-transcript"])
+
+
+@pytest.fixture(scope="module")
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(scope="module")
+async def mcp_client_session() -> AsyncGenerator[ClientSession, None]:
+    async with stdio_client(params) as streams:
+        async with ClientSession(streams[0], streams[1]) as session:
+            await session.initialize()
+            yield session
+
+
+@pytest.mark.anyio
+async def test_list_tools(mcp_client_session: ClientSession) -> None:
+    res = await mcp_client_session.list_tools()
+    assert any(tool.name == "get_transcript" for tool in res.tools)
+
+
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="Skipping this test on CI")
+@pytest.mark.anyio
+async def test_get_transcript(mcp_client_session: ClientSession) -> None:
+    video_id = "LPZh9BOjkQs"
+
+    expect = "\n".join((item.text for item in YouTubeTranscriptApi().fetch(video_id)))
+
+    res = await mcp_client_session.call_tool(
+        "get_transcript",
+        arguments={"url": f"https//www.youtube.com/watch?v={video_id}"},
+    )
+    assert isinstance(res.content[0], TextContent)
+    assert res.content[0].text == expect
+    assert not res.isError
+
+
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="Skipping this test on CI")
+@pytest.mark.anyio
+async def test_get_transcript_with_language(mcp_client_session: ClientSession) -> None:
+    video_id = "WjAXZkQSE2U"
+
+    expect = "\n".join((item.text for item in YouTubeTranscriptApi().fetch(video_id, ["ja"])))
+
+    res = await mcp_client_session.call_tool(
+        "get_transcript",
+        arguments={"url": f"https//www.youtube.com/watch?v={video_id}", "lang": "ja"},
+    )
+    assert isinstance(res.content[0], TextContent)
+    assert res.content[0].text == expect
+    assert not res.isError
+
+
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="Skipping this test on CI")
+@pytest.mark.anyio
+async def test_get_transcript_fallback_language(
+    mcp_client_session: ClientSession,
+) -> None:
+    video_id = "LPZh9BOjkQs"
+
+    expect = "\n".join((item.text for item in YouTubeTranscriptApi().fetch(video_id)))
+
+    res = await mcp_client_session.call_tool(
+        "get_transcript",
+        arguments={
+            "url": f"https//www.youtube.com/watch?v={video_id}",
+            "lang": "unknown",
+        },
+    )
+    assert isinstance(res.content[0], TextContent)
+    assert res.content[0].text == expect
+    assert not res.isError
+
+
+@pytest.mark.anyio
+async def test_get_transcript_invalid_url(mcp_client_session: ClientSession) -> None:
+    res = await mcp_client_session.call_tool(
+        "get_transcript", arguments={"url": "https//www.youtube.com/watch?vv=abcdefg"}
+    )
+    assert res.isError
+
+
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="Skipping this test on CI")
+@pytest.mark.anyio
+async def test_get_transcript_not_found(mcp_client_session: ClientSession) -> None:
+    res = await mcp_client_session.call_tool("get_transcript", arguments={"url": "https//www.youtube.com/watch?v=a"})
+    assert res.isError

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ dev = [
 requires-dist = [
     { name = "mcp", specifier = ">=1.3" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "youtube-transcript-api", specifier = ">=1" },
+    { name = "youtube-transcript-api", specifier = ">=1.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -826,13 +826,13 @@ wheels = [
 
 [[package]]
 name = "youtube-transcript-api"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/90/5b0adc298ec4f595fe75b3424b643b9eee9c038d06139c7f6919cd1ac1a1/youtube_transcript_api-1.0.0.tar.gz", hash = "sha256:eba94e886e0f0256cf2b74d5d2c9f3c3ad24746941d580c3efc675b21286e43c", size = 1911036 }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/2d/810b2b1d8cf401b257928f300415ec66933f82678ca27f273c2aedf42517/youtube_transcript_api-1.0.1.tar.gz", hash = "sha256:820977c8402e2e7f8ce86817e05044ddc8c5fe7085cb8058b9a21e14153a27ba", size = 1911393 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/11/30507c773124090130c3a355cc06b2636bfc77feed38afe9f94a4acc9357/youtube_transcript_api-1.0.0-py3-none-any.whl", hash = "sha256:c5637baa4808f76f22d188679074ac2c2a525882ee5c47d2bf4564771b2475c7", size = 1929126 },
+    { url = "https://files.pythonhosted.org/packages/dc/83/52d6730ca49723116ffcfe398854b6ef1ecc780e09203f6ba4b203fde15e/youtube_transcript_api-1.0.1-py3-none-any.whl", hash = "sha256:66b91279e239b21274ac6d91b55002eb9c418824aab70cd66a82954a09a298a2", size = 1929575 },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -300,6 +300,7 @@ name = "mcp-youtube-transcript"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "youtube-transcript-api" },
@@ -315,6 +316,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.8" },
     { name = "mcp", specifier = ">=1.3" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "youtube-transcript-api", specifier = ">=1.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -312,6 +312,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pre-commit-uv" },
     { name = "pytest" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -328,6 +329,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.1" },
     { name = "pre-commit-uv", specifier = ">=4.1.4" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
 
 [[package]]
@@ -542,6 +544,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of Changes

This pull request introduces significant enhancements and refactorings to the MCP server, alongside updates to project documentation and dependencies:

- **Proxy Support**: Added support for Webshare and generic HTTP/HTTPS proxies in the MCP server. Introduced CLI options for configuring proxy credentials, improving flexibility in restricted network environments.
- **Server Refactoring**: Modularized MCP server initialization into a dedicated `server` function, improving code clarity and testability. Adjusted the `main` function to leverage this new structure.
- **CLI Enhancements**: Introduced `click` library as a dependency and updated the project to include a CLI entry point, simplifying server initialization and usability.
- **Testing Updates**: Added `pytest-mock` dependency and updated tests to validate new proxy configurations and refactored server functionality.
- **Documentation Updates**: Enhanced README with usage details for the `get_transcript` tool and proxy configurations, providing examples for setup with Webshare and other proxies.
- **Dependency Updates**: Upgraded to `youtube-transcript-api` version 1.0.1 to fix previous issues, while updating pre-commit and project lockfiles accordingly.

