### PR TITLE
Add upload date and duration fields to `VideoInfo`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
           - "mcp>=1.9"
           - "youtube-transcript-api>=1.1.0"
           - "beautifulsoup4>=4.13.3"
+          - "humanize>=4.13"
           - "rich-click>=1.8.8"
           - "pytest>=8.3.5"
           - "pytest-mock>=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "beautifulsoup4>=4.13.3",
     "click>=8.1.8",
+    "humanize>=4.13",
     "mcp>=1.9",
     "pydantic>=2.10.6",
     "requests>=2.32.3",

--- a/uv.lock
+++ b/uv.lock
@@ -270,6 +270,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/1d/3062fcc89ee05a715c0b9bfe6490c00c576314f27ffee3a704122c6fd259/humanize-4.13.0.tar.gz", hash = "sha256:78f79e68f76f0b04d711c4e55d32bebef5be387148862cb1ef83d2b58e7935a0", size = 81884, upload-time = "2025-08-25T09:39:20.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c7/316e7ca04d26695ef0635dc81683d628350810eb8e9b2299fc08ba49f366/humanize-4.13.0-py3-none-any.whl", hash = "sha256:b810820b31891813b1673e8fec7f1ed3312061eab2f26e3fa192c393d11ed25f", size = 128869, upload-time = "2025-08-25T09:39:18.54Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.13"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +373,7 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
+    { name = "humanize" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "requests" },
@@ -387,6 +397,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.3" },
     { name = "click", specifier = ">=8.1.8" },
+    { name = "humanize", specifier = ">=4.13.0" },
     { name = "mcp", specifier = ">=1.9" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "requests", specifier = ">=2.32.3" },


### PR DESCRIPTION
This pull request enhances the `VideoInfo` class by adding `upload_date` and `duration` fields. A `_parse_time_info` helper function has been introduced to process time-related metadata, and the library `humanize` is now included for formatting duration. Tests have been updated accordingly to cover the new fields.