### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+permissions:
+  contents: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create package artifact
+        run: npx @anthropic-ai/mcpb pack
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "*.mcpb"
+          draft: true

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,3 +1,6 @@
 .*
 tests/
 __pycache__/
+Dockerfile
+server.json
+smithery.yaml


### PR DESCRIPTION
Added a new `release.yml` GitHub Actions workflow to automate the creation of draft releases for tags matching the pattern `v*.*.*`. Additionally, updated the `.mcpbignore` file to exclude files such as `Dockerfile`, `server.json`, and `smithery.yaml` from certain operations.