### PR TITLE
Make datetime handling timezone-aware

### DIFF
--- a/src/mcp_youtube_transcript/__init__.py
+++ b/src/mcp_youtube_transcript/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache, partial
 from itertools import islice
 from typing import AsyncIterator, Tuple
@@ -22,7 +22,7 @@ from bs4 import BeautifulSoup
 from mcp import ServerSession
 from mcp.server import FastMCP
 from mcp.server.fastmcp import Context
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, AwareDatetime
 from youtube_transcript_api import YouTubeTranscriptApi, FetchedTranscriptSnippet
 from youtube_transcript_api.proxies import WebshareProxyConfig, GenericProxyConfig, ProxyConfig
 from yt_dlp import YoutubeDL
@@ -83,14 +83,14 @@ class VideoInfo(BaseModel):
     title: str = Field(description="Title of the video")
     description: str = Field(description="Description of the video")
     uploader: str = Field(description="Uploader of the video")
-    upload_date: datetime = Field(description="Upload date of the video")
+    upload_date: AwareDatetime = Field(description="Upload date of the video")
     duration: str = Field(description="Duration of the video")
 
 
 def _parse_time_info(date: int, timestamp: int, duration: int) -> Tuple[datetime, str]:
     parsed_date = datetime.strptime(str(date), "%Y%m%d").date()
     parsed_time = datetime.strptime(str(timestamp), "%H%M%S%f").time()
-    upload_date = datetime.combine(parsed_date, parsed_time)
+    upload_date = datetime.combine(parsed_date, parsed_time, timezone.utc)
     duration_str = humanize.naturaldelta(timedelta(seconds=duration))
     return upload_date, duration_str
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,7 +5,7 @@
 #  This software is released under the MIT License.
 #
 #  http://opensource.org/licenses/mit-license.php
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 from typing import AsyncGenerator
 
@@ -376,12 +376,12 @@ async def test_get_video_info(mcp_client_session: ClientSession) -> None:
     )
     assert isinstance(res.content[0], TextContent)
 
-    info = VideoInfo.model_validate_json(res.content[0].text)
+    info = VideoInfo.model_validate_json(res.content[0].text, strict=True)
     assert info == expect
     assert not res.isError
 
 
 def test_parse_time_info() -> None:
     upload_date, duration = _parse_time_info(20250921, 1650496000, 1234567)
-    assert upload_date == datetime(2025, 9, 21, 16, 50, 49, 600000)
+    assert upload_date == datetime(2025, 9, 21, 16, 50, 49, 600000, timezone.utc)
     assert duration == humanize.naturaldelta(timedelta(seconds=1234567))


### PR DESCRIPTION
This pull request refactors the code to ensure timezone-aware `datetime` handling. Key changes include:

- Updating imports to include `timezone` where necessary.
- Switching to `AwareDatetime` for the `upload_date` field in `VideoInfo`.
- Adjusting `_parse_time_info` and related assertions to support timezone-aware `datetime` objects.
- Enabling strict validation for `VideoInfo` in `model_validate_json`.

These enhancements aim to improve reliability and consistency in time-related operations.