### PR TITLE
feat: support /shorts/, /embed/, and /live/ endpoints

### DIFF
--- a/src/mcp_youtube_transcript/__init__.py
+++ b/src/mcp_youtube_transcript/__init__.py
@@ -129,6 +129,8 @@ def _parse_video_id(url: str) -> str:
     parsed_url = urlparse(url)
     if parsed_url.hostname == "youtu.be":
         return parsed_url.path.lstrip("/")
+    elif parsed_url.path.startswith(("/shorts/", "/embed/", "/live/")):
+        return parsed_url.path.split("/")[2]
     else:
         q = parse_qs(parsed_url.query).get("v")
         if q is None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ from typing import Any, TypeGuard
 import pytest
 from youtube_transcript_api.proxies import WebshareProxyConfig, GenericProxyConfig
 
-from mcp_youtube_transcript import server, AppContext
+from mcp_youtube_transcript import server, AppContext, _parse_video_id
 
 
 def is_webshare_proxy_config(obj: Any) -> TypeGuard[WebshareProxyConfig]:
@@ -142,3 +142,29 @@ async def test_new_server_with_https_proxy() -> None:
         assert app_ctx.ytt_api._fetcher._proxy_config.http_url is None
         assert app_ctx.ytt_api._fetcher._proxy_config.https_url == https_proxy
         assert app_ctx.dlp.params.get("proxy") == proxy_config.to_requests_dict()["https"]
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://www.youtube.com/watch?v=tACfRW2f8ao", "tACfRW2f8ao"),
+        ("https://youtu.be/tACfRW2f8ao", "tACfRW2f8ao"),
+        ("https://www.youtube.com/shorts/tACfRW2f8ao", "tACfRW2f8ao"),
+        ("https://www.youtube.com/embed/tACfRW2f8ao", "tACfRW2f8ao"),
+        ("https://www.youtube.com/live/tACfRW2f8ao", "tACfRW2f8ao"),
+    ],
+)
+def test_parse_video_id(url: str, expected: str) -> None:
+    assert _parse_video_id(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.youtube.com/watch",
+        "https://www.youtube.com/live",
+    ],
+)
+def test_parse_video_id_invalid(url: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_video_id(url)


### PR DESCRIPTION
`_parse_video_id` currently handles only `youtu.be/<id>` and `watch?v=<id>` URLs; everything else raises "couldn't find a video ID." This adds `youtube.com/shorts/<id>`, `/embed/<id>`, and `/live/<id>` — all of which carry the ID as the first path segment. Failing on these pasteable URLs is a gap rather than intended behavior.

The fix is one `elif` branch matching the trailing-slashed prefixes and returning `path.split("/")[2]`. Trailing slashes are deliberate so a bare `/live` with no ID still fails with the existing `ValueError` instead of an `IndexError`.

## Testing
Added parametrized pure-function tests in `tests/test_server.py`: one for each URL form (using an ID whose leading char would be corrupted by naive prefix-stripping), and one asserting a clean `ValueError` for URLs with no ID. No network or cassette required.